### PR TITLE
[Merged by Bors] - Use correct case for framework names

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -89,7 +89,7 @@ parameters used in the test are as follows:
 | TF Serving2.1  `GPU` |           19395.129            |               53640.456                |             3.29E-05              |
 | TensorRT       `GPU` |           37342.687            |               163058.592               |             2.06E-05              |
 
-#### The test result of MNIST model in Tensorflow format
+#### The test result of MNIST model in TensorFlow format
 
 |                      | speed of client (pictures/sec) | speed of serving engine (pictures/sec) | tail latency of one picture (sec) |
 | -------------------- | :----------------------------: | :------------------------------------: | :-------------------------------: |
@@ -99,7 +99,7 @@ parameters used in the test are as follows:
 | TF Serving1.14 `GPU` |           19043.582            |               51448.587                |             3.31E-05              |
 | TF Serving2.1  `GPU` |           19244.343            |               50705.164                |             3.22E-05              |
 
-#### The test result of MNIST model in Pytorch format
+#### The test result of MNIST model in PyTorch format
 
 |                      | speed of client (pictures/sec) | speed of serving engine (pictures/sec) | tail latency of one picture (sec) |
 | -------------------- | :----------------------------: | :------------------------------------: | :-------------------------------: |
@@ -129,7 +129,7 @@ parameters used in the test are as follows:
 | TF Serving2.1  `GPU` |            170.680             |                420.814                 |              0.00348              |
 | TensorRT       `GPU` |            246.745             |                1381.023                |              0.00332              |
 
-#### The test result of ResNet50 model in Tensorflow format
+#### The test result of ResNet50 model in TensorFlow format
 
 |                      | speed of client (pictures/sec) | speed of serving engine (pictures/sec) | tail latency of one picture (sec) |
 | -------------------- | :----------------------------: | :------------------------------------: | :-------------------------------: |
@@ -139,7 +139,7 @@ parameters used in the test are as follows:
 | TF Serving1.14 `GPU` |            181.118             |                454.013                 |              0.00331              |
 | TF Serving2.1  `GPU` |            176.710             |                473.091                 |              0.00354              |
 
-#### The test result of ResNet50 model in Pytorch format
+#### The test result of ResNet50 model in PyTorch format
 
 |                      | speed of client (pictures/sec) | speed of serving engine (pictures/sec) | tail latency of one picture (sec) |
 | -------------------- | :----------------------------: | :------------------------------------: | :-------------------------------: |

--- a/docs/ReleaseNotes/0.1.0/ReleaseNotes.md
+++ b/docs/ReleaseNotes/0.1.0/ReleaseNotes.md
@@ -8,7 +8,7 @@
 ### Model Compiler
 
 1. A new framework which is easy to expand and maintain.
-2. Compilation of models trained from Keras, Tensorflow and Pytorch for better execution on CPU/GPU.
+2. Compilation of models trained from Keras, TensorFlow and PyTorch for better execution on CPU/GPU.
 
 | Training framework | Model format | Target runtime | compiled format |
 | ------------------ | ------------ | -------------- | --------------- |
@@ -64,7 +64,7 @@
 
 ### Benchmark Test Framework for Deep Learning Model
 
-1. A containalized solution which should automatically execute compiling models, loading runtime and compiled
+1. A containerized solution which should automatically execute compiling models, loading runtime and compiled
    models, starting inference service, then run inference client script, and finally generate testing results.
 2. Supports all the compilers and runtime that can be integrated into Adlik.
 3. Supported output: inference result, inference speed, delay of inference execution.


### PR DESCRIPTION
bors r+

Signed-off-by: Zhao Lufan <zhao.lufan30@zte.com.cn>