### PR TITLE
[Merged by Bors] - Only use tflite_ops, when tensorflow>=2.7.0 and the batch size of model is -1

### DIFF
--- a/model_compiler/src/model_compiler/compilers/keras_model_file_to_tflite_model.py
+++ b/model_compiler/src/model_compiler/compilers/keras_model_file_to_tflite_model.py
@@ -20,5 +20,7 @@ def compile_source(source: KerasModelFile, config: tflite_util.Config) -> TfLite
 
     model = tf.keras.models.load_model(filepath=source.model_path, custom_objects=custom_objects, compile=False)
     converter = tf.lite.TFLiteConverter.from_keras_model(model)
+    # tensorflow>=2.7.0, if batch size is -1, to avoid using tf_select_ops
+    converter._experimental_default_to_single_batch_in_tensor_list_ops = True  # pylint: disable=protected-access
     tflite_model = tflite_util.get_tflite_model(converter, config)
     return TfLiteModel(tflite_model, config.input_formats)

--- a/model_compiler/src/model_compiler/compilers/onnx_model_to_tflite_model.py
+++ b/model_compiler/src/model_compiler/compilers/onnx_model_to_tflite_model.py
@@ -17,7 +17,8 @@ def compile_source(source: OnnxModel) -> TfLiteModel:
         tf_representation.export_graph(directory)
         converter = tf.lite.TFLiteConverter.from_saved_model(directory)
         converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS, tf.lite.OpsSet.SELECT_TF_OPS]
-
+        # tensorflow>=2.7.0, if batch size is -1, to avoid using tf_select_ops
+        converter._experimental_default_to_single_batch_in_tensor_list_ops = True  # pylint: disable=protected-access
         tflite_model = converter.convert()
 
         return TfLiteModel(tflite_model, source.input_data_formats)

--- a/model_compiler/src/model_compiler/compilers/saved_model_file_to_tflite_model.py
+++ b/model_compiler/src/model_compiler/compilers/saved_model_file_to_tflite_model.py
@@ -19,6 +19,8 @@ def compile_source(source: SavedModelFile, config: Config) -> TfLiteModel:
         signature_keys = tf.saved_model.load(source.model_path, tags=['serve']).signatures
 
     converter = tf.lite.TFLiteConverter.from_saved_model(source.model_path, signature_keys=signature_keys)
+    # tensorflow>=2.7.0, if batch size is -1, to avoid using tf_select_ops
+    converter._experimental_default_to_single_batch_in_tensor_list_ops = True  # pylint: disable=protected-access
     tflite_model = get_tflite_model(converter, config)
 
     return TfLiteModel(tflite_model, config.input_formats)

--- a/model_compiler/src/model_compiler/compilers/saved_model_to_tflite_model.py
+++ b/model_compiler/src/model_compiler/compilers/saved_model_to_tflite_model.py
@@ -17,6 +17,8 @@ def compile_source(source: SavedModel, config: Config) -> TfLiteModel:
         source.save(directory)
 
         converter = tf.lite.TFLiteConverter.from_saved_model(directory)
+        # tensorflow>=2.7.0, if batch size is -1, to avoid using tf_select_ops
+        converter._experimental_default_to_single_batch_in_tensor_list_ops = True  # pylint: disable=protected-access
         tflite_model = get_tflite_model(converter, config)
         input_formats = [model_input.data_format for model_input in source.inputs]
 

--- a/model_compiler/tests/model_compiler/models/targets/test_tflite_model.py
+++ b/model_compiler/tests/model_compiler/models/targets/test_tflite_model.py
@@ -19,6 +19,8 @@ def _make_simple_tflite_model() -> TfLiteModel:
     model.compile(optimizer='sgd', loss='mean_squared_error')
     model.fit(input_x, output_y, epochs=1)
     converter = tf.lite.TFLiteConverter.from_keras_model(model)
+    # tensorflow>=2.7.0, if batch size is -1, to avoid using tf_select_ops
+    converter._experimental_default_to_single_batch_in_tensor_list_ops = True  # pylint: disable=protected-access
     tflite_model = converter.convert()
 
     return TfLiteModel(tflite_model=tflite_model, input_formats=[DataFormat.CHANNELS_LAST])
@@ -56,6 +58,8 @@ class TfLiteModelFileTestCase(TestCase):
         output_y = tf.keras.layers.Dense(10)(input_x)
         model = tf.keras.models.Model(inputs=[input_1, input_2], outputs=[output_y])
         converter = tf.lite.TFLiteConverter.from_keras_model(model)
+        # tensorflow>=2.7.0, if batch size is -1, to avoid using tf_select_ops
+        converter._experimental_default_to_single_batch_in_tensor_list_ops = True  # pylint: disable=protected-access
         tflite_model = converter.convert()
 
         tflite_model = TfLiteModel(tflite_model=tflite_model,


### PR DESCRIPTION
Signed-off-by: 靳伟昭 10307459 <jin.weizhao@zte.com.cn>